### PR TITLE
add viewonly flag to x11vnc to make VNC view only

### DIFF
--- a/selenium/vnc/chrome/entrypoint.sh
+++ b/selenium/vnc/chrome/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 SCREEN_RESOLUTION=${SCREEN_RESOLUTION:-"1920x1080x24"}
 DISPLAY=99
-x11vnc -display ":$DISPLAY" -passwd selenoid -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /home/selenium/x11vnc.log &
+x11vnc -display ":$DISPLAY" -passwd selenoid -shared -viewonly -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /home/selenium/x11vnc.log &
 /usr/bin/xvfb-run -l -n "$DISPLAY" -s "-ac -screen 0 $SCREEN_RESOLUTION -noreset -listen tcp" /usr/bin/chromedriver --port=4444 --whitelisted-ips='' --verbose

--- a/selenium/vnc/firefox/selenium/entrypoint.sh
+++ b/selenium/vnc/firefox/selenium/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 SCREEN_RESOLUTION=${SCREEN_RESOLUTION:-"1920x1080x24"}
 DISPLAY=99
-x11vnc -display ":$DISPLAY" -passwd selenoid -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
+x11vnc -display ":$DISPLAY" -passwd selenoid -viewonly -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
 /usr/bin/xvfb-run -l -n "$DISPLAY" -s "-ac -screen 0 $SCREEN_RESOLUTION -noreset -listen tcp" /usr/bin/java -Xmx256m -Djava.security.egd=file:/dev/./urandom -jar /usr/share/selenium/selenium-server-standalone.jar -port 4444 -browserTimeout 120

--- a/selenium/vnc/firefox/selenoid/entrypoint.sh
+++ b/selenium/vnc/firefox/selenoid/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 SCREEN_RESOLUTION=${SCREEN_RESOLUTION:-"1920x1080x24"}
 DISPLAY=99
-x11vnc -display ":$DISPLAY" -passwd selenoid -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
+x11vnc -display ":$DISPLAY" -passwd selenoid -shared -viewonly -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
 /usr/bin/xvfb-run -l -n "$DISPLAY" -s "-ac -screen 0 $SCREEN_RESOLUTION -noreset -listen tcp" /usr/bin/selenoid -conf /etc/selenoid/browsers.json -disable-docker -timeout 1h -enable-file-upload -capture-driver-logs

--- a/selenium/vnc/opera/blink/entrypoint.sh
+++ b/selenium/vnc/opera/blink/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 SCREEN_RESOLUTION=${SCREEN_RESOLUTION:-"1920x1080x24"}
 DISPLAY=99
-x11vnc -display ":$DISPLAY" -passwd selenoid -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /home/selenium/x11vnc.log &
+x11vnc -display ":$DISPLAY" -passwd selenoid -shared -viewonly -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /home/selenium/x11vnc.log &
 /usr/bin/xvfb-run -l -n "$DISPLAY" -s "-ac -screen 0 $SCREEN_RESOLUTION -noreset -listen tcp" /usr/bin/operadriver --port=4444 --whitelisted-ips='' --verbose

--- a/selenium/vnc/opera/presto/entrypoint.sh
+++ b/selenium/vnc/opera/presto/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 SCREEN_RESOLUTION=${SCREEN_RESOLUTION:-"1920x1080x24"}
 DISPLAY=99
-x11vnc -display ":$DISPLAY" -passwd selenoid -shared -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
+x11vnc -display ":$DISPLAY" -passwd selenoid -shared -viewonly -forever -loop500 -rfbport 5900 -rfbportv6 5900 -logfile /var/log/x11vnc.log &
 /usr/bin/xvfb-run -l -n "$DISPLAY" -s "-ac -screen 0 $SCREEN_RESOLUTION -noreset -listen tcp" /usr/bin/java -Xmx256m -Djava.security.egd=file:/dev/./urandom -jar /usr/share/selenium/selenium-server-standalone.jar -port 4444 -browserTimeout 120


### PR DESCRIPTION
I noticed that it's very easy to break a test when opening selenoid-ui with VNC enabled. Mouse can occasionally move or button pressed and test will be broken.

VNC in selenoid-ui is not very useful for interaction so I suggest to make it view only. Than a user can safely open VNC.