### PR TITLE
Install pulseaudio in Firefox container for compatibility with WebRTC

### DIFF
--- a/selenium/firefox/apt/Dockerfile.tmpl
+++ b/selenium/firefox/apt/Dockerfile.tmpl
@@ -9,15 +9,14 @@ RUN  \
         apt-get -y --no-install-recommends install pulseaudio firefox=$VERSION && \
         ($CLEANUP && rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*) || true
 
-RUN useradd seluser \
-         --shell /bin/bash  \
-         --create-home \
-  && usermod -a -G sudo seluser \
-  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
-  && echo 'seluser:secret' | chpasswd
+RUN \
+        adduser --system --home /home/selenium \
+        --ingroup nogroup --disabled-password --shell /bin/bash selenium && \
+        usermod -a -G sudo selenium && \
+        echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers
 
 RUN mkdir /video
 
-RUN chown seluser /video /var/log
+RUN chown selenium /video /var/log
 
-USER seluser
+USER selenium

--- a/selenium/firefox/apt/Dockerfile.tmpl
+++ b/selenium/firefox/apt/Dockerfile.tmpl
@@ -6,5 +6,18 @@ ARG CLEANUP
 RUN  \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         apt-get update && \
-        apt-get -y --no-install-recommends install firefox=$VERSION && \
+        apt-get -y --no-install-recommends install pulseaudio firefox=$VERSION && \
         ($CLEANUP && rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*) || true
+
+RUN useradd seluser \
+         --shell /bin/bash  \
+         --create-home \
+  && usermod -a -G sudo seluser \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'seluser:secret' | chpasswd
+
+RUN mkdir /video
+
+RUN chown seluser /video /var/log
+
+USER seluser

--- a/selenium/firefox/selenium/Dockerfile.server.tmpl
+++ b/selenium/firefox/selenium/Dockerfile.server.tmpl
@@ -8,4 +8,4 @@ COPY entrypoint.sh /
 EXPOSE 4444
 ENTRYPOINT /entrypoint.sh
 
-USER seluser
+USER selenium

--- a/selenium/firefox/selenium/Dockerfile.server.tmpl
+++ b/selenium/firefox/selenium/Dockerfile.server.tmpl
@@ -1,7 +1,11 @@
 FROM selenoid/dev_firefox:@@VERSION@@
 
+USER root
+
 COPY selenium-server-standalone.jar /usr/share/selenium/
 COPY entrypoint.sh /
 
 EXPOSE 4444
 ENTRYPOINT /entrypoint.sh
+
+USER seluser

--- a/selenium/firefox/selenoid/Dockerfile.driver.tmpl
+++ b/selenium/firefox/selenoid/Dockerfile.driver.tmpl
@@ -1,5 +1,7 @@
 FROM selenoid/dev_firefox:@@VERSION@@
 
+USER root
+
 COPY geckodriver /usr/bin/
 COPY selenoid /usr/bin/
 COPY browsers.json /etc/selenoid/
@@ -7,3 +9,5 @@ COPY entrypoint.sh /
 
 EXPOSE 4444
 ENTRYPOINT /entrypoint.sh
+
+USER seluser

--- a/selenium/firefox/selenoid/Dockerfile.driver.tmpl
+++ b/selenium/firefox/selenoid/Dockerfile.driver.tmpl
@@ -10,4 +10,4 @@ COPY entrypoint.sh /
 EXPOSE 4444
 ENTRYPOINT /entrypoint.sh
 
-USER seluser
+USER selenium

--- a/selenium/vnc/firefox/selenium/Dockerfile.tmpl
+++ b/selenium/vnc/firefox/selenium/Dockerfile.tmpl
@@ -10,4 +10,4 @@ RUN \
 
 COPY entrypoint.sh /
 
-USER seluser
+USER selenium

--- a/selenium/vnc/firefox/selenium/Dockerfile.tmpl
+++ b/selenium/vnc/firefox/selenium/Dockerfile.tmpl
@@ -1,5 +1,7 @@
 FROM selenoid/firefox:@@VERSION@@
 
+USER root
+
 RUN \
 	apt-get update && \
 	apt-get -y --no-install-recommends install x11vnc && \
@@ -7,3 +9,5 @@ RUN \
 	rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /
+
+USER seluser

--- a/selenium/vnc/firefox/selenoid/Dockerfile.tmpl
+++ b/selenium/vnc/firefox/selenoid/Dockerfile.tmpl
@@ -10,4 +10,4 @@ RUN \
 
 COPY entrypoint.sh /
 
-USER seluser
+USER selenium

--- a/selenium/vnc/firefox/selenoid/Dockerfile.tmpl
+++ b/selenium/vnc/firefox/selenoid/Dockerfile.tmpl
@@ -1,5 +1,7 @@
 FROM selenoid/firefox:@@VERSION@@
 
+USER root
+
 RUN \
 	apt-get update && \
 	apt-get -y --no-install-recommends install x11vnc && \
@@ -7,3 +9,5 @@ RUN \
 	rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /
+
+USER seluser


### PR DESCRIPTION
As of Firefox 53, in order to carry out tests of WebRTC applications using Firefox in Docker, the package `pulseaudio` needs to be installed (see more info [here](https://stackoverflow.com/questions/44775411/getusermedia-in-firefox-in-docker-not-working-when-using-audio)). Thanks to this [PR](https://github.com/SeleniumHQ/docker-selenium/pull/614), this package is already present in the Firefox docker image of SeleniumHQ. It would be very useful to be also in the Selenoid images.

This PR basically install `pulseaudio` in the Selenoid Firefox containers. Moreover, and due to the fact that `pulseaudio` cannot be executed as root by default, a non-root user is needed in the container (called `seluser` in the PR). I have tested the resulting image using a [WebRTC samples page](https://webrtc.github.io/samples/src/content/devices/input-output/) and it is working fine. Please consider to merge this PR in the master branch to be available in the next release.