### PR TITLE
Added configuration for browsers automation

### DIFF
--- a/selenium/automate_chrome.sh
+++ b/selenium/automate_chrome.sh
@@ -3,6 +3,7 @@ set -e
 input=$1
 driver_version=$2
 tag=$3
+test_failure_ignore=${TEST_FAILURE_IGNORE:-true}
 
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
     echo 'Usage: ./automate_chrome.sh <browser_version|package_file> <chromedriver_version> <tag_version>'
@@ -33,7 +34,7 @@ test_image(){
     tests_dir=../../selenoid-container-tests/
     if [ -d "$tests_dir" ]; then
         pushd "$tests_dir"
-        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=chrome -Dgrid.browser.version=$2 || true
+        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=chrome -Dgrid.browser.version=$2 || $test_failure_ignore
         popd
     else
         echo "Skipping tests as $tests_dir does not exist."

--- a/selenium/automate_firefox.sh
+++ b/selenium/automate_firefox.sh
@@ -4,6 +4,7 @@ input=$1
 server_version=$2
 tag=$3
 driver_version=$4
+test_failure_ignore=${TEST_FAILURE_IGNORE:-true}
 
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
     echo 'Usage: automate_firefox.sh <browser_version|package_file> <selenium_version|selenoid_version> <tag_version> [<geckodriver_version>]'
@@ -47,7 +48,7 @@ test_image(){
     tests_dir=../../selenoid-container-tests/
     if [ -d "$tests_dir" ]; then
         pushd "$tests_dir"
-        mvn clean test -Dgrid.connection.url="http://localhost:4445/wd/hub" -Dgrid.browser.name=firefox -Dgrid.browser.version=$2 || true
+        mvn clean test -Dgrid.connection.url="http://localhost:4445/wd/hub" -Dgrid.browser.name=firefox -Dgrid.browser.version=$2 || $test_failure_ignore
         popd
     else
         echo "Skipping tests as $tests_dir does not exist."

--- a/selenium/automate_opera.sh
+++ b/selenium/automate_opera.sh
@@ -3,6 +3,7 @@ set -e
 input=$1
 driver_version=$2
 tag=$3
+test_failure_ignore=${TEST_FAILURE_IGNORE:-true}
 
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
     echo 'Usage: automate_opera.sh <browser_version|package_file> <operadriver_version> <tag_version>'
@@ -33,7 +34,7 @@ test_image(){
     tests_dir=../../selenoid-container-tests/
     if [ -d "$tests_dir" ]; then
         pushd "$tests_dir"
-        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=opera -Dgrid.browser.version=$2 || true
+        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=opera -Dgrid.browser.version=$2 || $test_failure_ignore
         popd
     else
         echo "Skipping tests as $tests_dir does not exist."

--- a/selenium/automate_yandex.sh
+++ b/selenium/automate_yandex.sh
@@ -3,6 +3,7 @@ set -e
 input=$1
 driver_version=$2
 tag=$3
+test_failure_ignore=${TEST_FAILURE_IGNORE:-true}
 
 if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
     echo 'Usage: automate_yandex.sh <browser_version|package_file> <yandexdriver_version> <tag_version>'
@@ -33,7 +34,7 @@ test_image(){
     tests_dir=../../selenoid-container-tests/
     if [ -d "$tests_dir" ]; then
         pushd "$tests_dir"
-        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=chrome -Dgrid.browser.version=$2 || true
+        mvn clean test -Dgrid.connection.url="http://localhost:4445/" -Dgrid.browser.name=chrome -Dgrid.browser.version=$2 || $test_failure_ignore
         popd
     else
         echo "Skipping tests as $tests_dir does not exist."

--- a/selenium/build-dev.sh
+++ b/selenium/build-dev.sh
@@ -15,6 +15,7 @@ tag_version="$version"
 if [ -n "$5" ]; then
     tag_version=$5
 fi
+disable_docker_cache=${DISABLE_DOCKER_CACHE:-false}
 browser_name="${browser%%/*}"
 image_name="dev_"$browser_name
 if [ "$cleanup" == "false" ]; then
@@ -48,6 +49,9 @@ if [ "$browser" == "chrome/local" -o "$browser" == "opera/blink/local" -o "$brow
         exit 1
     fi
     additional_docker_args="--add-host apt-repo:$host_ip"
+fi
+if [ "$disable_docker_cache" == "true" ]; then
+    additional_docker_args+=" --no-cache"
 fi
 pushd "$dir_name"
 echo "Creating image $tag with cleanup=$cleanup..."

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -72,6 +72,7 @@ set -x
 mode=$1
 version=$2
 tag=$4
+disable_docker_cache=${DISABLE_DOCKER_CACHE:-false}
 dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
 pushd "$dir_name"
@@ -103,8 +104,12 @@ fi
 if [ -f "entrypoint.sh" ]; then
     cp entrypoint.sh "$dir_name/entrypoint.sh"
 fi
+additional_docker_args=""
+if [ "$disable_docker_cache" == "true" ]; then
+    additional_docker_args+=" --no-cache"
+fi
 pushd "$dir_name"
-docker build -t "$tag" .
+docker build $additional_docker_args -t "$tag" .
 popd
 rm -Rf "$dir_name"
 exit 0


### PR DESCRIPTION
Use optional variables to ignore test failures and disable Docker cache:
{TEST_FAILURE_IGNORE:-true}
{DISABLE_DOCKER_CACHE:-false}