### PR TITLE
Add Docker labels with browser image info

### DIFF
--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -77,17 +77,24 @@ dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
 pushd "$dir_name"
 template_file="Dockerfile.driver.tmpl"
+additional_docker_args=""
 if [ "$mode" == "chromedriver" ]; then
     download_chromedriver "$3"
+    additional_docker_args+="--label driver=chromedriver_$3"
 elif [ "$mode" == "operadriver" ]; then
     download_operadriver "$3"
+    additional_docker_args+="--label driver=operadriver_$3"
 elif [ "$mode" == "yandexdriver" ]; then
     download_yandexdriver "$3"
+    additional_docker_args+="--label driver=yandexdriver_$3"
 elif [ "$mode" == "selenoid" ]; then
     download_selenoid "$3"
+    additional_docker_args+="--label selenoid=$3"
     download_geckodriver "$5"
+    additional_docker_args+=" --label driver=geckodriver_$5"
 elif [ "$mode" == "selenium" ]; then
     download_selenium "$3"
+    additional_docker_args+="--label selenium=$3"
     template_file="Dockerfile.server.tmpl"
 else
     echo "Unsupported mode: will do nothing. Exiting."
@@ -104,7 +111,6 @@ fi
 if [ -f "entrypoint.sh" ]; then
     cp entrypoint.sh "$dir_name/entrypoint.sh"
 fi
-additional_docker_args=""
 if [ "$disable_docker_cache" == "true" ]; then
     additional_docker_args+=" --no-cache"
 fi

--- a/selenium/chrome/apt/Dockerfile
+++ b/selenium/chrome/apt/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION
 ARG CLEANUP
 
+LABEL browser=google-chrome-stable_$VERSION
+
 RUN \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \

--- a/selenium/chrome/local/Dockerfile
+++ b/selenium/chrome/local/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION=noop
 ARG CLEANUP=noop
 
+LABEL browser=google-chrome-stable_$VERSION
+
 RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install gconf-service \

--- a/selenium/firefox/apt/Dockerfile.tmpl
+++ b/selenium/firefox/apt/Dockerfile.tmpl
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0@@REQUIRES_JAVA@@
 ARG VERSION
 ARG CLEANUP
 
+LABEL browser=firefox_$VERSION
+
 RUN  \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         apt-get update && \

--- a/selenium/firefox/local/Dockerfile.tmpl
+++ b/selenium/firefox/local/Dockerfile.tmpl
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0@@REQUIRES_JAVA@@
 ARG VERSION
 ARG CLEANUP
 
+LABEL browser=firefox_$VERSION
+
 RUN \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         ( \

--- a/selenium/firefox/local/Dockerfile.tmpl
+++ b/selenium/firefox/local/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN \
                 apt-get -y install libc6:i386 libncurses5:i386 libstdc++6:i386 libgtk-3-0:i386 libasound2:i386 libdbus-glib-1-2:i386 libxt6:i386 libatomic1:i386 libcairo-gobject2:i386 libstartup-notification0:i386 libx11-xcb1:i386 && \
                 mkdir flashplayer && \
                 cd flashplayer && \
-                wget -O flashplayer.tar.gz https://fpdownload.adobe.com/pub/flashplayer/pdc/32.0.0.270/flash_player_ppapi_linux.i386.tar.gz && \
+                wget -O flashplayer.tar.gz https://fpdownload.adobe.com/pub/flashplayer/pdc/32.0.0.293/flash_player_ppapi_linux.i386.tar.gz && \
                 tar xvzf flashplayer.tar.gz && \
                 cp libpepflashplayer.so /usr/lib/flashplugin-installer/libflashplayer.so && \
                 cd .. && \

--- a/selenium/opera/blink/apt/Dockerfile
+++ b/selenium/opera/blink/apt/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION
 ARG CLEANUP
 
+LABEL browser=opera-stable_$VERSION
+
 RUN  \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         wget -O- http://deb.opera.com/archive.key | apt-key add - && \

--- a/selenium/opera/blink/local/Dockerfile
+++ b/selenium/opera/blink/local/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION=noop
 ARG CLEANUP=noop
 
+LABEL browser=opera-stable_$VERSION
+
 RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install gconf-service \

--- a/selenium/yandex/apt/Dockerfile
+++ b/selenium/yandex/apt/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION=19.4.2.698-1
 ARG CLEANUP
 
+LABEL browser=yandex-browser-beta_$VERSION
+
 RUN  \
         ( [ "$CLEANUP" != "true" ] && rm -f /etc/apt/apt.conf.d/docker-clean ) || true && \
         wget -O- https://repo.yandex.ru/yandex-browser/YANDEX-BROWSER-KEY.GPG | apt-key add - && \

--- a/selenium/yandex/local/Dockerfile
+++ b/selenium/yandex/local/Dockerfile
@@ -3,6 +3,8 @@ FROM selenoid/base:5.0
 ARG VERSION=noop
 ARG CLEANUP=noop
 
+LABEL browser=yandex-browser-beta_$VERSION
+
 RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install gconf-service \


### PR DESCRIPTION
Useful to quickly verify what browser package, driver and selenoid versions have been installed inside the browser image by inspecting it