### PR TITLE
firefox-esr support for automate_firefox.sh

### DIFF
--- a/selenium/build-dev.sh
+++ b/selenium/build-dev.sh
@@ -61,6 +61,8 @@ if [ "$channel" != "default" ]; then
                 dev)
                     additional_docker_args+=" --build-arg PACKAGE=firefox-trunk --build-arg PPA=ppa:ubuntu-mozilla-daily/ppa"
                     ;;
+		esr)
+		    additional_docker_args+=" --build-arg PACKAGE=firefox-esr --build-arg PPA=ppa:mozillateam/ppa"
             esac
             ;;
         chrome)

--- a/selenium/firefox/apt/Dockerfile.tmpl
+++ b/selenium/firefox/apt/Dockerfile.tmpl
@@ -17,6 +17,6 @@ RUN  \
         ) || true && \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 libavcodec57 $PACKAGE=$VERSION && \
-        ( [ "$PACKAGE" = "firefox-trunk" ] && ln /usr/bin/$PACKAGE /usr/bin/firefox ) || true && \
+        ( [ "$PACKAGE" != "firefox" ] && ln /usr/bin/$PACKAGE /usr/bin/firefox ) || true && \
         firefox --version && \
         ($CLEANUP && rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*) || true


### PR DESCRIPTION
now possible : ./automate_firefox.sh 68.10.0esr+build1-0ubuntu0.18.04.1 latest 68-esr 0.26.0 esr
i can add changes to readme if you approve in general
1 failed test :
![image](https://user-images.githubusercontent.com/41294185/85876791-84602800-b7d6-11ea-824a-886f79e1d586.png)
