### PR TITLE
target github direct download link for geckodriver, operadriver, sele…

### DIFF
--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -33,13 +33,11 @@ download_selenium() {
 
 download_geckodriver() {
     local download_url=""
-
     if [ "$1" == "latest" ]; then
         download_url=$(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
     else
         download_url="https://github.com/mozilla/geckodriver/releases/download/v$1/geckodriver-v$1-linux64.tar.gz"
     fi
-
     wget -O geckodriver.tar.gz "$download_url"
     tar xvzf geckodriver.tar.gz
     rm -Rf geckodriver.tar.gz
@@ -53,13 +51,11 @@ download_chromedriver() {
 
 download_operadriver() {
     local download_url=""
-
     if [ "$1" == "latest" ]; then
         download_url=$(wget -qO- "https://api.github.com/repos/operasoftware/operachromiumdriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
     else
         download_url="https://github.com/operasoftware/operachromiumdriver/releases/download/v.$1/operadriver_linux64.zip"
     fi
-
     wget -O operadriver.zip "$download_url"
     unzip operadriver.zip
     if [ -d operadriver_linux64 ]; then
@@ -88,13 +84,11 @@ download_yandexdriver() {
 
 download_selenoid() {
     local download_url=""
-
     if [ "$1" == "latest" ]; then
         download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
     else
         download_url="https://github.com/aerokube/selenoid/releases/download/$1/selenoid_linux_amd64"
     fi
-
     wget -O selenoid "$download_url"
     chmod +x selenoid
 }

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -90,7 +90,7 @@ download_selenoid() {
     local download_url=""
 
     if [ "$1" == "latest" ]; then
-        download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$tag" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
+        download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
     else
         download_url="https://github.com/aerokube/selenoid/releases/download/$1/selenoid_linux_amd64"
     fi

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -32,13 +32,14 @@ download_selenium() {
 }
 
 download_geckodriver() {
-    local tag=""
+    local download_url=""
+
     if [ "$1" == "latest" ]; then
-        tag="$1"
+        download_url=$(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
     else
-        tag="tags/v$1"
+        download_url="https://github.com/mozilla/geckodriver/releases/download/v$1/geckodriver-v$1-linux64.tar.gz"
     fi
-    local download_url=$(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/$tag" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
+
     wget -O geckodriver.tar.gz "$download_url"
     tar xvzf geckodriver.tar.gz
     rm -Rf geckodriver.tar.gz
@@ -51,13 +52,14 @@ download_chromedriver() {
 }
 
 download_operadriver() {
-    local tag=""
+    local download_url=""
+
     if [ "$1" == "latest" ]; then
-        tag="$1"
+        download_url=$(wget -qO- "https://api.github.com/repos/operasoftware/operachromiumdriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
     else
-        tag="tags/v.$1"
+        download_url="https://github.com/operasoftware/operachromiumdriver/releases/download/v.$1/operadriver_linux64.zip"
     fi
-    local download_url=$(wget -qO- "https://api.github.com/repos/operasoftware/operachromiumdriver/releases/$tag" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
+
     wget -O operadriver.zip "$download_url"
     unzip operadriver.zip
     if [ -d operadriver_linux64 ]; then
@@ -85,13 +87,14 @@ download_yandexdriver() {
 }
 
 download_selenoid() {
-    local tag=""
+    local download_url=""
+
     if [ "$1" == "latest" ]; then
-        tag="$1"
+        download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$tag" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
     else
-        tag="tags/$1"
+        download_url="https://github.com/aerokube/selenoid/releases/download/$1/selenoid_linux_amd64"
     fi
-    local download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$tag" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
+
     wget -O selenoid "$download_url"
     chmod +x selenoid
 }


### PR DESCRIPTION
Target github direct download link for geckodriver, operadriver, selenoid, and preserve backward compatibility of the use of 'latest' wildcard.
* So we don't use github API when a specific version is required 
(e.g ```./automate_firefox.sh 68.10.0esr+build1-0ubuntu0.18.04.1 1.10.0 68.1 0.24.0 esr```)
* If ```latest``` is used instead of  the specific version number, the previous implementation using github API takes effect.
* Yandex driver is a case too singular to bypass the github API call because each Yandex version doesn't necessarily have a linux release and [this way of linking release](https://docs.github.com/en/github/administering-a-repository/linking-to-releases) is not always apply.