### PR TITLE
Fix driver and selenoid Docker labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Here `64.0.3417.92` is `opera-stable` package version for Ubuntu 18.04, `77.0.38
 
 * To build a Yandex image use the following command:
 ```
-$ ./automate_yandex.sh 19.9.3.358-1 19.9.3 19.9
+$ ./automate_yandex.sh 20.4.3.268-1 20.4.3.321 20.4
 ```
-Here `19.9.3.358-1` is `yandex-browser-beta` package version for Ubuntu 18.04, `19.9.3` is [Yandexdriver](https://github.com/yandex/YandexDriver/tree/master/linux) version, `19.9` is Docker tag to be applied.
+Here `20.4.3.268-1` is `yandex-browser-beta` package version for Ubuntu 18.04, `20.4.3.321` is [Yandexdriver](https://github.com/yandex/YandexDriver/releases) Linux asset version, `20.4` is Docker tag to be applied.
 
 * To build an Android image use the following command:
 ```

--- a/selenium/automate_firefox.sh
+++ b/selenium/automate_firefox.sh
@@ -35,8 +35,17 @@ browser_version=$input
 method="firefox/apt"
 runner="selenoid"
 requires_java="false"
-numeric_version=$(echo "$tag" | awk -F '.' '{print $1}' )
+numeric_version=$(echo "$tag" | awk -F '.' '{print $1}')
 driver_version=""
+
+get_latest_selenoid() {
+    echo "$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/latest" | jq -r '.tag_name')"
+}
+
+get_latest_geckodriver() {
+    echo "$(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/latest" | jq -r '.tag_name' | awk -F 'v' '{print $2}')"
+}
+
 if [ $numeric_version -lt 48 ]; then
     channel=${4:-"default"}
     runner="selenium"
@@ -47,6 +56,12 @@ else
     if [ -z "$driver_version" ]; then
         echo 'Driver version is required for Firefox 48 and above'
         exit 1
+    fi
+    if [ "$server_version" == "latest" ]; then
+        server_version=$(get_latest_selenoid)
+    fi
+    if [ "$driver_version" == "latest" ]; then
+        driver_version=$(get_latest_geckodriver)
     fi
 fi
 

--- a/selenium/automate_opera.sh
+++ b/selenium/automate_opera.sh
@@ -41,6 +41,14 @@ if [ -f "$input" ]; then
     method="opera/blink/local"
 fi
 
+get_latest_operadriver() {
+    echo "$(wget -qO- "https://api.github.com/repos/operasoftware/operachromiumdriver/releases/latest" | jq -r '.tag_name' | awk -F 'v.' '{print $2}')"
+}
+
+if [ "$driver_version" == "latest" ]; then
+    driver_version=$(get_latest_operadriver)
+fi
+
 ./build-dev.sh $method $browser_version $channel true
 if [ "$method" == "opera/blink/apt" ]; then
     ./build-dev.sh $method $browser_version $channel false

--- a/selenium/automate_yandex.sh
+++ b/selenium/automate_yandex.sh
@@ -40,6 +40,14 @@ if [ -f "$input" ]; then
     method="yandex/local"
 fi
 
+get_latest_yandexdriver() {
+    echo "$(wget -qO- "https://api.github.com/repos/yandex/YandexDriver/releases" | jq -r 'first(.[].assets[].name | select(contains("linux")))' | awk -F '-' '{print $2}' | awk -F '-' '{print $1}')"
+}
+
+if [ "$driver_version" == "latest" ]; then
+    driver_version=$(get_latest_yandexdriver)
+fi
+
 ./build-dev.sh $method $browser_version default true
 if [ "$method" == "yandex/apt" ]; then
     ./build-dev.sh $method $browser_version default false

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -32,13 +32,7 @@ download_selenium() {
 }
 
 download_geckodriver() {
-    local download_url=""
-    if [ "$1" == "latest" ]; then
-        download_url=$(wget -qO- "https://api.github.com/repos/mozilla/geckodriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
-    else
-        download_url="https://github.com/mozilla/geckodriver/releases/download/v$1/geckodriver-v$1-linux64.tar.gz"
-    fi
-    wget -O geckodriver.tar.gz "$download_url"
+    wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$1/geckodriver-v$1-linux64.tar.gz
     tar xvzf geckodriver.tar.gz
     rm -Rf geckodriver.tar.gz
 }
@@ -50,13 +44,7 @@ download_chromedriver() {
 }
 
 download_operadriver() {
-    local download_url=""
-    if [ "$1" == "latest" ]; then
-        download_url=$(wget -qO- "https://api.github.com/repos/operasoftware/operachromiumdriver/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux64"))')
-    else
-        download_url="https://github.com/operasoftware/operachromiumdriver/releases/download/v.$1/operadriver_linux64.zip"
-    fi
-    wget -O operadriver.zip "$download_url"
+    wget -O operadriver.zip https://github.com/operasoftware/operachromiumdriver/releases/download/v.$1/operadriver_linux64.zip
     unzip operadriver.zip
     if [ -d operadriver_linux64 ]; then
         cp operadriver_linux64/operadriver ./operadriver
@@ -66,30 +54,15 @@ download_operadriver() {
 }
 
 download_yandexdriver() {
-    local download_url=""
-    if [ "$1" == "latest" ]; then
-        download_url=$(wget -qO- "https://api.github.com/repos/yandex/YandexDriver/releases" | jq -r 'first(.[].assets[].browser_download_url | select(contains("linux")))')
-    else
-        download_url=$(wget -qO- "https://api.github.com/repos/yandex/YandexDriver/releases/tags/v$1-stable" | jq -r '.assets[].browser_download_url | select(contains("linux"))')
-        if [ -z "$download_url" ]; then
-            echo "Unsupported Yandexdriver version: $1"
-            exit 1
-        fi
-    fi
-    wget -O yandexdriver.zip "$download_url"
+    local build_version=$(echo "$1" | cut -d. -f1-3)
+    wget -O yandexdriver.zip https://github.com/yandex/YandexDriver/releases/download/v$build_version-stable/yandexdriver-$1-linux.zip
     unzip yandexdriver.zip
     chmod +x yandexdriver
     rm yandexdriver.zip
 }
 
 download_selenoid() {
-    local download_url=""
-    if [ "$1" == "latest" ]; then
-        download_url=$(wget -qO- "https://api.github.com/repos/aerokube/selenoid/releases/$1" | jq -r '.assets[].browser_download_url | select(contains("linux_amd64"))')
-    else
-        download_url="https://github.com/aerokube/selenoid/releases/download/$1/selenoid_linux_amd64"
-    fi
-    wget -O selenoid "$download_url"
+    wget -O selenoid https://github.com/aerokube/selenoid/releases/download/$1/selenoid_linux_amd64
     chmod +x selenoid
 }
 


### PR DESCRIPTION
After having added support to retrieve latest drivers, the `driver` and `selenoid` Docker labels in the Browser images had the wrong value of `latest` instead of the actual version. This PR fixes that issue. 