### PR TITLE
Pass proxy conf to docker build context

### DIFF
--- a/selenium/base/base_2/rebuild-old.sh
+++ b/selenium/base/base_2/rebuild-old.sh
@@ -15,8 +15,17 @@ mkdir -p "$dir_name"
 
 cat "Dockerfile" | sed -e "s|selenoid/base:1.0|$image|g" > "$dir_name/Dockerfile"
 pushd "$dir_name"
+
+additional_docker_args=""
+if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
+    additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
+fi
+if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
+    additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
+fi
+
 echo "Adding fonts and encodings to $image..."
-docker build -t "$image" .
+docker build $additional_docker_args -t "$image" .
 popd
 rm -Rf "$dir_name"
 exit 0

--- a/selenium/base/base_2/rebuild-old.sh
+++ b/selenium/base/base_2/rebuild-old.sh
@@ -15,17 +15,8 @@ mkdir -p "$dir_name"
 
 cat "Dockerfile" | sed -e "s|selenoid/base:1.0|$image|g" > "$dir_name/Dockerfile"
 pushd "$dir_name"
-
-additional_docker_args=""
-if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
-    additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
-fi
-if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
-    additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
-fi
-
 echo "Adding fonts and encodings to $image..."
-docker build $additional_docker_args -t "$image" .
+docker build -t "$image" .
 popd
 rm -Rf "$dir_name"
 exit 0

--- a/selenium/build-dev.sh
+++ b/selenium/build-dev.sh
@@ -25,7 +25,6 @@ fi
 tag="selenoid/"$image_name":"$tag_version
 dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
-
 additional_docker_args=""
 if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
     additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
@@ -33,7 +32,6 @@ fi
 if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
     additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
 fi
-
 if [ "$browser" == "firefox/local" -o "$browser" == "firefox/apt" ]; then
     requires_java_value=""
     if [ "$requires_java" == "true" ]; then

--- a/selenium/build-dev.sh
+++ b/selenium/build-dev.sh
@@ -25,7 +25,15 @@ fi
 tag="selenoid/"$image_name":"$tag_version
 dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
+
 additional_docker_args=""
+if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
+    additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
+fi
+if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
+    additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
+fi
+
 if [ "$browser" == "firefox/local" -o "$browser" == "firefox/apt" ]; then
     requires_java_value=""
     if [ "$requires_java" == "true" ]; then

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -107,7 +107,15 @@ dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
 pushd "$dir_name"
 template_file="Dockerfile.driver.tmpl"
+
 additional_docker_args=""
+if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
+    additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
+fi
+if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
+    additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
+fi
+
 if [ "$mode" == "chromedriver" ]; then
     download_chromedriver "$3"
     additional_docker_args+="--label driver=chromedriver:$3"

--- a/selenium/build.sh
+++ b/selenium/build.sh
@@ -107,7 +107,6 @@ dir_name="/tmp/$(uuidgen | sed -e 's|-||g')"
 mkdir -p "$dir_name"
 pushd "$dir_name"
 template_file="Dockerfile.driver.tmpl"
-
 additional_docker_args=""
 if [ -n "$http_proxy" -a -n "$https_proxy" ]; then
     additional_docker_args+="--build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy "
@@ -115,7 +114,6 @@ fi
 if [ -n "$HTTP_PROXY" -a -n "$HTTPS_PROXY" ]; then
     additional_docker_args+="--build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY "
 fi
-
 if [ "$mode" == "chromedriver" ]; then
     download_chromedriver "$3"
     additional_docker_args+="--label driver=chromedriver:$3"


### PR DESCRIPTION
Allow to propagate the proxy configuration, usually stored in linux environment variable, to the docker build context (part of #249).

* So behind corporate proxy, linux machines usually have ```http_proxy``` and ```https_proxy``` environment variables setted. wget command uses these variables to be able to download tiers dependencies (geckodriver, selenoid...).
* And when we propagate these environment variables to docker build context through the ```--build-arg``` argument, the commands scripted in the Dockerfile can pass the corporate proxy as well, and then use ```apt```...
If linux machines (used to build the selenoid-images project) doesn't have these environment variables, they can be set like this, before we run ```./automate_firefox.sh ...``` :

```sh
export http_proxy=http://[<login:password>@]<proxy_hostname>[<proxy_port>]
export https_proxy=http[s]://[<login:password>@]<proxy_hostname>[<proxy_port>]
```
And unset like this (if needed) when the build is done :
```sh
unset http_proxy https_proxy
```
Using this method, if proxy credential is configured in the environment variables, they don't have to be spread elsewhere (in CI conf files for example).