### PR TITLE
Fix for #262

### DIFF
--- a/selenium/android/Dockerfile
+++ b/selenium/android/Dockerfile
@@ -22,7 +22,7 @@ RUN \
 	    curl \
 	    iproute2 \
 	    nodejs \
-	    openjdk-8-jre-headless \
+	    openjdk-8-jdk-headless \
 	    unzip \
 	    xvfb \
 	    libpulse0 \


### PR DESCRIPTION
Espresso cannot compile without jdk installed

```
 [Gradle] [STDERR] > Kotlin could not find the required JDK tools in the Java installation '/usr/lib/jvm/java-8-openjdk-amd64/jre' used by Gradle. Make sure Gradle is running on a JDK, not JRE.
```

fixes #262