### PR TITLE
fixed build docker image with yandex-browser

### DIFF
--- a/build/yandex.go
+++ b/build/yandex.go
@@ -61,7 +61,7 @@ func (yb *YandexBrowser) Build() error {
 		return fmt.Errorf("create temporary dir: %v", err)
 	}
 
-	image, err := NewImage("opera", destDir, yb.Requirements)
+	image, err := NewImage("yandex", destDir, yb.Requirements)
 	if err != nil {
 		return fmt.Errorf("init image: %v", err)
 	}


### PR DESCRIPTION
Starting a session manually via SelenoidUI does not work, but with autotests via Selenoid everything is ok

```./selenoid-images yandex -b 20.8.0.864-1 -d 20.7.3.176 -t selenoid/yandex-browser:20.8 -n --test```