### PR TITLE
Fixed tests run for Yandex browser

### DIFF
--- a/build/yandex.go
+++ b/build/yandex.go
@@ -78,7 +78,7 @@ func (yb *YandexBrowser) Build() error {
 		return fmt.Errorf("build image: %v", err)
 	}
 
-	err = image.Test(yb.TestsDir, "chrome", pkgTagVersion)
+	err = image.Test(yb.TestsDir, "yandex", pkgTagVersion)
 	if err != nil {
 		return fmt.Errorf("test image: %v", err)
 	}


### PR DESCRIPTION
This PR must be merged after https://github.com/aerokube/selenoid-container-tests/pull/8
Tests pass for
`./selenoid-images yandex -b 20.8.3.132-1 -t selenoid/yandex:20.8 -d 20.8.3.132 -n --test`