### PR TITLE
[Android] Added fresh cmd-line tools and Android 12

### DIFF
--- a/selenium/android/Dockerfile
+++ b/selenium/android/Dockerfile
@@ -34,7 +34,8 @@ RUN \
         x11vnc \
         feh \
         wmctrl \
-	    libglib2.0-0 && \
+	    libglib2.0-0  \
+        lib32stdc++6 && \
     apt-get clean && \
     rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*
 
@@ -47,9 +48,9 @@ COPY fluxbox/aerokube.png /usr/share/images/fluxbox/
 COPY --from=go /devtools/devtools /usr/bin/
 
 # Android SDK
-ENV ANDROID_HOME /opt/android-sdk-linux
-ENV PATH /opt/android-sdk-linux/platform-tools:/opt/android-sdk-linux/tools:/opt/android-sdk-linux/tools/bin:/opt/android-sdk-linux/emulator:$PATH
-ENV LD_LIBRARY_PATH ${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/gles_swiftshader:${ANDROID_HOME}/emulator/lib64/qt/lib:${ANDROID_HOME}/emulator/lib64/vulkan:${LD_LIBRARY_PATH}
+ENV ANDROID_SDK_ROOT /opt
+ENV PATH $ANDROID_SDK_ROOT/cmdline-tools:$ANDROID_SDK_ROOT/cmdline-tools/tools/bin:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/platform-tools:$PATH
+ENV LD_LIBRARY_PATH ${ANDROID_SDK_ROOT}/emulator/lib64:${ANDROID_SDK_ROOT}/emulator/lib64/gles_swiftshader:${ANDROID_SDK_ROOT}/emulator/lib64/qt/lib:${ANDROID_SDK_ROOT}/emulator/lib64/vulkan:${LD_LIBRARY_PATH}
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 ARG ANDROID_DEVICE=""
@@ -64,26 +65,27 @@ ARG SDCARD_SIZE="500"
 ARG USERDATA_SIZE="500"
 
 RUN \
-	curl -o sdk-tools.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
-	mkdir -p /opt/android-sdk-linux /root/.config/Android\ Open\ Source\ Project/ && \
-	unzip -q sdk-tools.zip -d /opt/android-sdk-linux && \
+	curl -o sdk-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip && \
+	mkdir -p /opt/cmdline-tools /root/.config/Android\ Open\ Source\ Project/ && \
+	unzip -q sdk-tools.zip -d /opt/cmdline-tools && \
+    mv /opt/cmdline-tools/cmdline-tools /opt/cmdline-tools/tools &&\
 	rm sdk-tools.zip && \
 	yes | sdkmanager --licenses
 
 RUN \
-	sdkmanager "emulator" "tools" "platform-tools" "$BUILD_TOOLS" "platforms;$PLATFORM" "$EMULATOR_IMAGE" && \
+	sdkmanager "tools" "platform-tools" "$BUILD_TOOLS" "platforms;$PLATFORM" "$EMULATOR_IMAGE" && \
 	mksdcard "$SDCARD_SIZE"M sdcard.img && \
 	echo "no" | ( \
-	    ([ -n "$ANDROID_DEVICE" ] && avdmanager create avd -n "$AVD_NAME" -k "$EMULATOR_IMAGE" --abi "$ANDROID_ABI" --device "$ANDROID_DEVICE" --sdcard /sdcard.img ) || \
-	    avdmanager create avd -n "$AVD_NAME" -k "$EMULATOR_IMAGE" --abi "$ANDROID_ABI" --sdcard /sdcard.img \
+	    ([ -n "$ANDROID_DEVICE" ] && avdmanager create avd -n "$AVD_NAME" -k "$EMULATOR_IMAGE" --abi "$ANDROID_ABI" --device "$ANDROID_DEVICE" --sdcard sdcard.img ) || \
+	    avdmanager create avd -n "$AVD_NAME" -k "$EMULATOR_IMAGE" --abi "$ANDROID_ABI" --sdcard sdcard.img \
     ) && \
 	ldconfig && \
 	( \
 	    resize2fs /root/.android/avd/$AVD_NAME.avd/userdata.img "$USERDATA_SIZE"M || \
-	    /opt/android-sdk-linux/emulator/qemu-img resize -f raw /root/.android/avd/$AVD_NAME.avd/userdata.img "$USERDATA_SIZE"M \
+	    /opt/emulator/qemu-img resize -f raw /root/.android/avd/$AVD_NAME.avd/userdata.img "$USERDATA_SIZE"M \
     ) && \
 	([ -z "$REPLACE_IMG" ] || mv /root/.android/avd/$AVD_NAME.avd/userdata.img /root/.android/avd/$AVD_NAME.avd/userdata-qemu.img ) && \
-	rm /opt/android-sdk-linux/system-images/$PLATFORM/$EMULATOR_IMAGE_TYPE/"$ANDROID_ABI"/userdata.img
+	rm /opt/system-images/$PLATFORM/$EMULATOR_IMAGE_TYPE/"$ANDROID_ABI"/userdata.img
 
 COPY ["Emulator.conf", "/root/.config/Android Open Source Project/Emulator.conf"]
 COPY emulator-snapshot.sh tmp/chromedriver* *.apk /usr/bin/

--- a/selenium/android/Dockerfile
+++ b/selenium/android/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=go /devtools/devtools /usr/bin/
 
 # Android SDK
 ENV ANDROID_SDK_ROOT /opt
-ENV PATH $ANDROID_SDK_ROOT/cmdline-tools:$ANDROID_SDK_ROOT/cmdline-tools/tools/bin:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/platform-tools:$PATH
+ENV PATH $ANDROID_SDK_ROOT/cmdline-tools:$ANDROID_SDK_ROOT/cmdline-tools/tools/bin:$ANDROID_SDK_ROOT/tools:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$PATH
 ENV LD_LIBRARY_PATH ${ANDROID_SDK_ROOT}/emulator/lib64:${ANDROID_SDK_ROOT}/emulator/lib64/gles_swiftshader:${ANDROID_SDK_ROOT}/emulator/lib64/qt/lib:${ANDROID_SDK_ROOT}/emulator/lib64/vulkan:${LD_LIBRARY_PATH}
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 

--- a/selenium/android/android.conf
+++ b/selenium/android/android.conf
@@ -1,2 +1,2 @@
-/opt/android-sdk-linux/emulator/lib64
-/opt/android-sdk-linux/emulator/lib64/gles_swiftshader
+/opt/emulator/lib64
+/opt/emulator/lib64/gles_swiftshader

--- a/selenium/android/entrypoint.sh
+++ b/selenium/android/entrypoint.sh
@@ -59,7 +59,7 @@ if [ -n "$STOP" ]; then exit 0; fi
 if [ "$ENABLE_VNC" != "true" ] && [ "$ENABLE_VIDEO" != "true" ]; then
     EMULATOR_ARGS="$EMULATOR_ARGS -no-window"
 fi
-ANDROID_AVD_HOME=/root/.android/avd DISPLAY="$DISPLAY" /opt/android-sdk-linux/emulator/emulator ${EMULATOR_ARGS} -writable-system -no-boot-anim -no-audio -no-jni -avd @AVD_NAME@ -sdcard /sdcard.img -skin "$SKIN" -skindir /opt/android-sdk-linux/platforms/@PLATFORM@/skins/ -gpu swiftshader_indirect -ranchu -qemu -enable-kvm &
+ANDROID_AVD_HOME=/root/.android/avd DISPLAY="$DISPLAY" /opt/emulator/emulator ${EMULATOR_ARGS} -writable-system -no-boot-anim -no-audio -no-jni -avd @AVD_NAME@ -sdcard sdcard.img -skin "$SKIN" -skindir /opt/platforms/@PLATFORM@/skins/ -gpu swiftshader_indirect -ranchu -qemu -enable-kvm &
 EMULATOR_PID=$!
 
 if [ "$ENABLE_VNC" == "true" ]; then

--- a/selenium/automate_android.sh
+++ b/selenium/automate_android.sh
@@ -31,7 +31,7 @@ validate_android_version(){
     type=${2:-"default"}
     abi=${3:-"x86"}
     avd_name="android$version-1"
-    build_tools="build-tools;29.0.2"
+    build_tools="build-tools;31.0.0"
     replace_img="y"
     case "$version" in
 	4.4)
@@ -79,6 +79,11 @@ validate_android_version(){
 	11.0)
         platform="android-30"
         emulator_image="system-images;android-30;$type;$abi"
+        replace_img=""
+		;;
+ 12.0)
+        platform="android-31"
+        emulator_image="system-images;android-31;$type;$abi"
         replace_img=""
 		;;
 	*)
@@ -151,7 +156,7 @@ mkdir -p "$TMP_DIR"
 cp android/entrypoint.sh "$TMP_DIR/entrypoint.sh"
 cp -r ../static/chrome/devtools "$TMP_DIR/devtools"
 
-appium_version=$(request_answer "Specify Appium version:" "1.18.1")
+appium_version=$(request_answer "Specify Appium version:" "1.22.0")
 
 until [ "$?" -ne 0 ]; do
     android_image_type=$(request_answer "Specify Android image type (possible values: \"default\", \"google_apis\", \"google_apis_playstore\", \"android-tv\", \"android-wear\"):" "default")


### PR DESCRIPTION
- ANDROID_HOME replaced by ANDROID_SDK_ROOT
- Changed path to sdk due to package refactoring of [fresh cmd-line tools](https://stackoverflow.com/questions/60440509/android-command-line-tools-sdkmanager-always-shows-warning-could-not-create-se/61176718#61176718)
- up appium default version

built image with 12 android can find [here](https://hub.docker.com/repository/docker/budim/selenoid-android) 