### PR TITLE
Selenoid endpoint /download/ returns file metadata and file hash sum

### DIFF
--- a/selenium/base/fileserver/main_test.go
+++ b/selenium/base/fileserver/main_test.go
@@ -28,18 +28,36 @@ func TestDownloadAndRemoveFile(t *testing.T) {
 	tempFile, _ := os.CreateTemp(dir, "fileserver")
 	_ = os.WriteFile(tempFile.Name(), []byte("test-data"), 0644)
 	tempFileName := filepath.Base(tempFile.Name())
+	tempFileStat, _ := tempFile.Stat()
 	resp, err := http.Get(withUrl("/" + tempFileName))
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, resp, Code{200})
 	_, err = os.Stat(tempFile.Name())
 	AssertThat(t, err, Is{nil})
 
+	var files []FileInfo
+
 	rsp, err := http.Get(withUrl("/?json"))
 	AssertThat(t, err, Is{nil})
 	AssertThat(t, rsp, Code{http.StatusOK})
-	var files []string
 	AssertThat(t, rsp, IsJson{&files})
-	AssertThat(t, files, EqualTo{[]string{tempFileName}})
+	AssertThat(t, files, EqualTo{[]FileInfo{{
+		Name:         tempFileName,
+		Size:         tempFileStat.Size(),
+		LastModified: tempFileStat.ModTime().Unix(),
+	}}})
+
+	hash, _ := getHash(tempFile.Name(), "md5")
+	rsp, err = http.Get(withUrl("/?json&hash=md5"))
+	AssertThat(t, err, Is{nil})
+	AssertThat(t, rsp, Code{http.StatusOK})
+	AssertThat(t, rsp, IsJson{&files})
+	AssertThat(t, files, EqualTo{[]FileInfo{{
+		Name:         tempFileName,
+		Size:         tempFileStat.Size(),
+		LastModified: tempFileStat.ModTime().Unix(),
+		HashSum:      hash,
+	}}})
 
 	req, _ := http.NewRequest(http.MethodDelete, withUrl("/"+tempFileName), nil)
 	resp, err = http.DefaultClient.Do(req)


### PR DESCRIPTION
Returns meta information about files. First of all, their modification time (in milliseconds) and size (in bytes).
```
[
  {
    name: "some-file.txt",
    size: 20100,
    lastModified: 1675024208981
  }
]
```
When passing the parameter hash=md5 returns the hash sum of the file. Use md5, sha1 or sha256
```
[
  {
    name: "some-file.txt",
    size: 20100,
    lastModified: 1675024208981,
    hashSum: "as87as9dahs98ahsd9as78Astdgasd87as"
  }
]
```